### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/builder/source/cache.ts
+++ b/builder/source/cache.ts
@@ -1,10 +1,14 @@
 import * as Zod from 'zod'
 import * as Fs from 'node:fs'
 import * as Process from 'node:process'
+import * as Path from 'node:path'
 import { FetchAdShieldDomains } from './references/index.js'
 
-const CachePath = (Process.env.INIT_CWD ? Process.env.INIT_CWD : Process.cwd()) + '/.buildcache'
-const CacheDomainsPath = CachePath + '/domains.json'
+const BaseCacheDir = (Process.env.INIT_CWD && Path.isAbsolute(Process.env.INIT_CWD))
+  ? Process.env.INIT_CWD
+  : Process.cwd()
+const CachePath = Path.join(Path.resolve(BaseCacheDir), '.buildcache')
+const CacheDomainsPath = Path.join(CachePath, 'domains.json')
 
 export function CreateCache(Domains: Set<string>) {
   if (!Fs.existsSync(CachePath)) {

--- a/builder/source/cache.ts
+++ b/builder/source/cache.ts
@@ -4,10 +4,14 @@ import * as Process from 'node:process'
 import * as Path from 'node:path'
 import { FetchAdShieldDomains } from './references/index.js'
 
-const BaseCacheDir = (Process.env.INIT_CWD && Path.isAbsolute(Process.env.INIT_CWD))
-  ? Process.env.INIT_CWD
-  : Process.cwd()
-const CachePath = Path.join(Path.resolve(BaseCacheDir), '.buildcache')
+const ProjectRoot = Path.resolve(Process.cwd())
+const EnvInitCwd = Process.env.INIT_CWD && Path.isAbsolute(Process.env.INIT_CWD)
+  ? Path.resolve(Process.env.INIT_CWD)
+  : null
+const BaseCacheDir = (EnvInitCwd && (EnvInitCwd === ProjectRoot || EnvInitCwd.startsWith(ProjectRoot + Path.sep)))
+  ? EnvInitCwd
+  : ProjectRoot
+const CachePath = Path.join(BaseCacheDir, '.buildcache')
 const CacheDomainsPath = Path.join(CachePath, 'domains.json')
 
 export function CreateCache(Domains: Set<string>) {


### PR DESCRIPTION
Potential fix for [https://github.com/FilteringDev/tinyShield/security/code-scanning/10](https://github.com/FilteringDev/tinyShield/security/code-scanning/10)

In general, to fix this kind of issue you should avoid directly trusting environment variables or other unvalidated inputs when constructing filesystem paths. Normalize the path, optionally restrict it to be within an expected root, or fall back to a known-safe value when the input is missing or invalid.

For this specific code, the simplest low-impact fix is:

- Derive a base directory for the cache from `Process.env.INIT_CWD` only if it looks like a valid absolute path without suspicious segments; otherwise, fall back to `Process.cwd()`.
- Use `path.resolve` to normalize the cache directory and then append `'.buildcache'` as a path segment instead of string concatenation.
- This keeps functional behavior the same when `INIT_CWD` is a normal absolute path, but removes the direct trust in an arbitrary environment string and makes the path construction explicit and safe.

Concretely, in `builder/source/cache.ts`:

- Add an import for Node’s `path` module.
- Replace the direct string concatenation in `CachePath` with a small helper that:
  - Chooses a base directory: `Process.env.INIT_CWD` if it is an absolute path, otherwise `Process.cwd()`.
  - Uses `Path.resolve` and `Path.join` to construct `CachePath`.
- Leave the rest of the logic (create directory, read/write cache files) unchanged.

No additional methods are strictly required beyond a bit of inlined logic at the constant declaration site, and the only new import needed is the built-in `node:path` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
